### PR TITLE
Patches for #29 and #30

### DIFF
--- a/src/main/java/de/kopis/glacier/GlacierUploader.java
+++ b/src/main/java/de/kopis/glacier/GlacierUploader.java
@@ -32,7 +32,6 @@ import java.net.URL;
 import joptsimple.OptionSet;
 
 import org.apache.commons.configuration.CompositeConfiguration;
-import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.configuration.SystemConfiguration;
 import org.apache.commons.logging.Log;
@@ -74,7 +73,7 @@ public final class GlacierUploader {
   }
 
   private static CompositeConfiguration setupConfig() {
-    CompositeConfiguration config = new CompositeConfiguration();
+    final CompositeConfiguration config = new CompositeConfiguration();
     config.addConfiguration(new SystemConfiguration());
     try {
       File configFile = new File(System.getProperty("user.home"),".glacieruploaderrc");

--- a/src/main/java/de/kopis/glacier/commands/CreateVaultCommand.java
+++ b/src/main/java/de/kopis/glacier/commands/CreateVaultCommand.java
@@ -70,6 +70,6 @@ public class CreateVaultCommand extends AbstractCommand {
 
   @Override
   public boolean valid(OptionSet options, GlacierUploaderOptionParser optionParser) {
-    return options.has(optionParser.CREATE_VAULT) && options.has(optionParser.VAULT);
+    return options.has(optionParser.CREATE_VAULT);
   }
 }

--- a/src/main/java/de/kopis/glacier/commands/DeleteArchiveCommand.java
+++ b/src/main/java/de/kopis/glacier/commands/DeleteArchiveCommand.java
@@ -58,7 +58,7 @@ public class DeleteArchiveCommand extends AbstractCommand {
 
   @Override
   public boolean valid(OptionSet options, GlacierUploaderOptionParser optionParser) {
-    return options.has(optionParser.DELETE_ARCHIVE) && options.has(optionParser.VAULT);
+    return options.has(optionParser.DELETE_ARCHIVE) && options.hasArgument(optionParser.DELETE_ARCHIVE);
   }
 
 }

--- a/src/main/java/de/kopis/glacier/commands/DeleteVaultCommand.java
+++ b/src/main/java/de/kopis/glacier/commands/DeleteVaultCommand.java
@@ -56,6 +56,6 @@ public class DeleteVaultCommand extends AbstractCommand {
 
   @Override
   public boolean valid(OptionSet options, GlacierUploaderOptionParser optionParser) {
-    return options.has(optionParser.DELETE_VAULT) && options.has(optionParser.VAULT);
+    return options.has(optionParser.DELETE_VAULT);
   }
 }

--- a/src/main/java/de/kopis/glacier/commands/DownloadArchiveCommand.java
+++ b/src/main/java/de/kopis/glacier/commands/DownloadArchiveCommand.java
@@ -62,7 +62,6 @@ public class DownloadArchiveCommand extends AbstractCommand {
 
   @Override
   public boolean valid(OptionSet options, GlacierUploaderOptionParser optionParser) {
-    return options.has(optionParser.DOWNLOAD) && options.has(optionParser.VAULT)
-        && options.has(optionParser.TARGET_FILE);
+    return options.has(optionParser.DOWNLOAD) && options.has(optionParser.TARGET_FILE);
   }
 }

--- a/src/main/java/de/kopis/glacier/commands/UploadArchiveCommand.java
+++ b/src/main/java/de/kopis/glacier/commands/UploadArchiveCommand.java
@@ -67,6 +67,6 @@ public class UploadArchiveCommand extends AbstractCommand {
 
   @Override
   public boolean valid(OptionSet options, GlacierUploaderOptionParser optionParser) {
-    return options.has(optionParser.UPLOAD) && options.has(optionParser.VAULT);
+    return options.has(optionParser.UPLOAD);
   }
 }

--- a/src/main/java/de/kopis/glacier/commands/UploadMultipartArchiveCommand.java
+++ b/src/main/java/de/kopis/glacier/commands/UploadMultipartArchiveCommand.java
@@ -178,6 +178,6 @@ public class UploadMultipartArchiveCommand extends AbstractCommand {
 
   @Override
   public boolean valid(OptionSet options, GlacierUploaderOptionParser optionParser) {
-    return options.has(optionParser.MULTIPARTUPLOAD) && options.has(optionParser.VAULT);
+    return options.has(optionParser.MULTIPARTUPLOAD) && options.hasArgument(optionParser.MULTIPARTUPLOAD);
   }
 }

--- a/src/main/java/de/kopis/glacier/parsers/GlacierUploaderOptionParser.java
+++ b/src/main/java/de/kopis/glacier/parsers/GlacierUploaderOptionParser.java
@@ -121,7 +121,7 @@ public class GlacierUploaderOptionParser extends OptionParser {
 		}, "URL or Region handle of the amazon AWS endpoint where your vault is").withRequiredArg().ofType(String.class);
 
 		if (config.containsKey("endpoint")) {
-			endpointBuilder.defaultsTo(config.getString("endpoint"));
+			endpointBuilder.defaultsTo(formatEndpointUrl(config.getString("endpoint")));
 		}
 		return endpointBuilder;
 	}
@@ -219,7 +219,7 @@ public class GlacierUploaderOptionParser extends OptionParser {
 				add("delete");
 				add("d");
 			}
-		}, "deletes an existing archive").withOptionalArg().ofType(String.class);
+		}, "deletes an existing archive").withRequiredArg().ofType(String.class);
 	}
 
 	@SuppressWarnings("serial")


### PR DESCRIPTION
This completely fixes #29 and partially #30.
#29: Some commands required the --vault option to be set. But if a configuration file is used, the option won't be set. This check was already done in the main method and has been removed from the commands.
#30: Delete archive option must have a argument.
