### PR TITLE
New AWS version allows to use new Amazon regions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk</artifactId>
-                <version>1.11.313</version>
+                <version>1.11.490</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
I've changed version of aws-java-sdk dependency to allow use of new AWS' regions.

![issue](https://user-images.githubusercontent.com/9265526/51922774-fcf86480-23e9-11e9-8fa6-9e45855c9c7c.jpeg)
