### PR TITLE
Minor usability changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ aws.properties
 bin
 .idea
 *.iml
-*.log
+*.log.vscode
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ aws.properties
 bin
 .idea
 *.iml
-*.log.vscode
+*.log
 .vscode

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Command-line options
     -l, --list-inventory                    retrieve the inventory listing of a vault
     -m, --multipartupload <File>            start uploading a new archive in chunks
     -o, --download                          download an existing archive
-    -p, --partsize [Integer]                sets the size of each part for multipart uploads (default: 10485760)
+    -p, --partsize [Integer]                sets the size of each part for multipart uploads (must be a power of 2) (default: 16777216)
     -r, --delete-vault                      deletes an existing vault
     -s, --list-vaults                       lists all available vaults
     -t, --target <File>                     filename to store downloaded archive

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/AbortMultipartArchiveUploadCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/AbortMultipartArchiveUploadCommand.java
@@ -37,7 +37,7 @@ import joptsimple.OptionSet;
  * @author Kendal Montgomery theWizK@yahoo.com
  * @version 1.0
  */
-public class AbortMultipartArchiveUploadCommand extends AbstractCommand {
+public class AbortMultipartArchiveUploadCommand extends AbstractGlacierCommand {
 
     public AbortMultipartArchiveUploadCommand(AmazonGlacier client, AmazonSQS sqs, AmazonSNS sns) {
         super(client, sqs, sns);

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/AbstractCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/AbstractCommand.java
@@ -22,38 +22,47 @@ package de.kopis.glacier.commands;
  * #L%
  */
 
-import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.services.glacier.AmazonGlacier;
-import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sqs.AmazonSQS;
+
 import de.kopis.glacier.parsers.GlacierUploaderOptionParser;
 import joptsimple.OptionSet;
 
+/**
+ * Base class for all commands.
+ * 
+ */
 public abstract class AbstractCommand {
     protected final Logger log;
 
-    protected AWSCredentials credentials = null;
-    protected AmazonGlacier client = null;
-    protected AmazonSQS sqs = null;
-    protected AmazonSNS sns = null;
-
-    public AbstractCommand(AmazonGlacier client, AmazonSQS sqs, AmazonSNS sns) {
-        Validate.notNull(client);
-        Validate.notNull(sqs);
-        Validate.notNull(sns);
-
-        this.client = client;
-        this.sqs = sqs;
-        this.sns = sns;
-
+    public AbstractCommand() {
         this.log = LoggerFactory.getLogger(this.getClass());
     }
 
+    /**
+     * Called to execute the command.
+     * @param options
+     * @param optionParser
+     */
     public abstract void exec(OptionSet options, GlacierUploaderOptionParser optionParser);
 
+    /**
+     * Called to ask the command if it's valid for the supplied arguments.
+     * 
+     * @param options
+     * @param optionParser
+     * @return
+     */
     public abstract boolean valid(OptionSet options, GlacierUploaderOptionParser optionParser);
 
+    /**
+     * Called to ask the command to verify if the parameters are valid for the command.
+     * 
+     * @param options
+     * @param optionParser
+     * @throws IllegalArgumentException
+     */
+    public void verifyArguments(OptionSet options, GlacierUploaderOptionParser optionParser) throws IllegalArgumentException {
+        
+    }
 }

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/AbstractGlacierCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/AbstractGlacierCommand.java
@@ -22,41 +22,34 @@ package de.kopis.glacier.commands;
  * #L%
  */
 
+import org.apache.commons.lang3.Validate;
+
 import de.kopis.glacier.parsers.GlacierUploaderOptionParser;
 import joptsimple.OptionSet;
 
-import java.io.IOException;
-import java.io.OutputStream;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.services.glacier.AmazonGlacier;
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sqs.AmazonSQS;
 
-public class HelpCommand extends AbstractCommand {
+/**
+ * Base class for Glacier commands.
+ * 
+ */
+public abstract class AbstractGlacierCommand extends AbstractCommand {
+    protected AWSCredentials credentials = null;
+    protected AmazonGlacier client = null;
+    protected AmazonSQS sqs = null;
+    protected AmazonSNS sns = null;
 
-    private final OutputStream out;
-
-    public HelpCommand() {
-        this(System.out);
-    }
-
-    public HelpCommand(final OutputStream out) {
+    public AbstractGlacierCommand(AmazonGlacier client, AmazonSQS sqs, AmazonSNS sns) {
         super();
-        this.out = out;
-    }
+        Validate.notNull(client);
+        Validate.notNull(sqs);
+        Validate.notNull(sns);
 
-    @Override
-    public void exec(OptionSet options, GlacierUploaderOptionParser optionParser) {
-        if (!options.has(optionParser.help)) {
-            log.info("Ooops, can't determine what you want to do. Check your options." +
-                    System.getProperty("line.separator"));
-        }
-        try {
-            optionParser.printHelpOn(out);
-        } catch (final IOException e) {
-            log.error("Can not print help", e);
-        }
+        this.client = client;
+        this.sqs = sqs;
+        this.sns = sns;
     }
-
-    @Override
-    public boolean valid(OptionSet options, GlacierUploaderOptionParser optionParser) {
-        return options.has(optionParser.help);
-    }
-
 }

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/CreateVaultCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/CreateVaultCommand.java
@@ -36,7 +36,7 @@ import de.kopis.glacier.parsers.GlacierUploaderOptionParser;
 import de.kopis.glacier.printers.VaultPrinter;
 import joptsimple.OptionSet;
 
-public class CreateVaultCommand extends AbstractCommand {
+public class CreateVaultCommand extends AbstractGlacierCommand {
     private final VaultPrinter printer;
     private final OutputStream out;
 

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/DeleteArchiveCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/DeleteArchiveCommand.java
@@ -30,7 +30,7 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import de.kopis.glacier.parsers.GlacierUploaderOptionParser;
 import joptsimple.OptionSet;
 
-public class DeleteArchiveCommand extends AbstractCommand {
+public class DeleteArchiveCommand extends AbstractGlacierCommand {
 
     public DeleteArchiveCommand(AmazonGlacier client, AmazonSQS sqs, AmazonSNS sns) {
         super(client, sqs, sns);

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/DeleteVaultCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/DeleteVaultCommand.java
@@ -30,7 +30,7 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import de.kopis.glacier.parsers.GlacierUploaderOptionParser;
 import joptsimple.OptionSet;
 
-public class DeleteVaultCommand extends AbstractCommand {
+public class DeleteVaultCommand extends AbstractGlacierCommand {
   public DeleteVaultCommand(AmazonGlacier client, AmazonSQS sqs, AmazonSNS sns) {
     super(client, sqs, sns);
   }

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/DownloadArchiveCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/DownloadArchiveCommand.java
@@ -33,7 +33,7 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import de.kopis.glacier.parsers.GlacierUploaderOptionParser;
 import joptsimple.OptionSet;
 
-public class DownloadArchiveCommand extends AbstractCommand {
+public class DownloadArchiveCommand extends AbstractGlacierCommand {
 
     private ArchiveTransferManager atm;
 

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/ListJobsCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/ListJobsCommand.java
@@ -38,7 +38,7 @@ import java.io.OutputStream;
 /**
  * Lists recents jobs for the current vault.
  */
-public class ListJobsCommand extends AbstractCommand {
+public class ListJobsCommand extends AbstractGlacierCommand {
 
     private JobPrinter printer;
     private OutputStream out;

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/ListVaultCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/ListVaultCommand.java
@@ -36,7 +36,7 @@ import de.kopis.glacier.parsers.GlacierUploaderOptionParser;
 import de.kopis.glacier.printers.VaultPrinter;
 import joptsimple.OptionSet;
 
-public class ListVaultCommand extends AbstractCommand {
+public class ListVaultCommand extends AbstractGlacierCommand {
     private final VaultPrinter vaultPrinter;
     private final OutputStream outputStream;
 

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/ReceiveArchivesListCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/ReceiveArchivesListCommand.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 
-public class ReceiveArchivesListCommand extends AbstractCommand {
+public class ReceiveArchivesListCommand extends AbstractGlacierCommand {
 
     private final VaultInventoryPrinter printer;
     private final OutputStream out;

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/RequestArchivesListCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/RequestArchivesListCommand.java
@@ -34,7 +34,7 @@ import joptsimple.OptionSet;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 
-public class RequestArchivesListCommand extends AbstractCommand {
+public class RequestArchivesListCommand extends AbstractGlacierCommand {
 
     public RequestArchivesListCommand(final AmazonGlacier client, final AmazonSQS sqs, final AmazonSNS sns) {
         super(client, sqs, sns);

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/TreeHashArchiveCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/TreeHashArchiveCommand.java
@@ -31,7 +31,7 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import de.kopis.glacier.parsers.GlacierUploaderOptionParser;
 import joptsimple.OptionSet;
 
-public class TreeHashArchiveCommand extends AbstractCommand {
+public class TreeHashArchiveCommand extends AbstractGlacierCommand {
 
     public TreeHashArchiveCommand(final AmazonGlacier client, final AmazonSQS sqs, final AmazonSNS sns) {
         super(client, sqs, sns);

--- a/glacieruploader-command/src/main/java/de/kopis/glacier/commands/UploadArchiveCommand.java
+++ b/glacieruploader-command/src/main/java/de/kopis/glacier/commands/UploadArchiveCommand.java
@@ -39,7 +39,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-public class UploadArchiveCommand extends AbstractCommand {
+public class UploadArchiveCommand extends AbstractGlacierCommand {
 
     public static final ScheduledExecutorService SCHEDULED_POOL = Executors.newScheduledThreadPool(1);
     public static final int PROGRESS_PRINT_PERIOD = 5;

--- a/glacieruploader-command/src/test/java/de/kopis/glacier/commands/CommandFactoryTest.java
+++ b/glacieruploader-command/src/test/java/de/kopis/glacier/commands/CommandFactoryTest.java
@@ -47,7 +47,7 @@ public class CommandFactoryTest {
         sqs = createMock(AmazonSQS.class);
         sns = createMock(AmazonSNS.class);
 
-        CommandFactory.setDefaultCommand(new HelpCommand(client, sqs, sns));
+        CommandFactory.setDefaultCommand(new HelpCommand());
     }
 
     @Test

--- a/glacieruploader-command/src/test/java/de/kopis/glacier/commands/HelpCommandTest.java
+++ b/glacieruploader-command/src/test/java/de/kopis/glacier/commands/HelpCommandTest.java
@@ -43,7 +43,7 @@ public class HelpCommandTest extends AbstractCommandTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         // no need to specify options
         final OptionSet options = optionParser.parse("--help");
-        final HelpCommand command = new HelpCommand(client, sqs, sns, out);
+        final HelpCommand command = new HelpCommand(out);
 
         assertTrue(command.valid(options, optionParser));
         command.exec(options, optionParser);
@@ -57,7 +57,7 @@ public class HelpCommandTest extends AbstractCommandTest {
     @Test
     public void execWithoutOption() {
         final OptionSet options = optionParser.parse();
-        final HelpCommand command = new HelpCommand(client, sqs, sns, System.out);
+        final HelpCommand command = new HelpCommand(System.out);
         command.exec(options, optionParser);
     }
 
@@ -69,7 +69,7 @@ public class HelpCommandTest extends AbstractCommandTest {
         expectLastCall().andThrow(new IOException("dummy exception from junit test"));
         replay(out);
 
-        final HelpCommand command = new HelpCommand(client, sqs, sns, out);
+        final HelpCommand command = new HelpCommand(out);
         command.exec(options, optionParser);
     }
 

--- a/glacieruploader-command/src/test/java/de/kopis/glacier/commands/UploadMultipartArchiveCommandTest.java
+++ b/glacieruploader-command/src/test/java/de/kopis/glacier/commands/UploadMultipartArchiveCommandTest.java
@@ -53,7 +53,8 @@ public class UploadMultipartArchiveCommandTest extends AbstractCommandTest {
             fw.write(UUID.randomUUID().toString());
         }
 
-        final OptionSet options = optionParser.parse("--vault", "dummy", "-m", tempFile.getAbsolutePath(), "--partsize", "1234");
+        // create option set with partsize being a power of 2 (required)
+        final OptionSet options = optionParser.parse("--vault", "dummy", "-m", tempFile.getAbsolutePath(), "--partsize", "1048576");
 
         final InitiateMultipartUploadResult initiateResult = new InitiateMultipartUploadResult();
         initiateResult.setUploadId(UUID.randomUUID().toString());

--- a/glacieruploader-parsers/src/test/java/de/kopis/glacier/parsers/GlacierUploaderOptionParserTest.java
+++ b/glacieruploader-parsers/src/test/java/de/kopis/glacier/parsers/GlacierUploaderOptionParserTest.java
@@ -213,4 +213,18 @@ public class GlacierUploaderOptionParserTest {
         final List<File> files = optionsParser.mergeNonOptionsFiles(optionsFiles, nonOptions);
         Assert.assertEquals(tempFile.getName(), files.get(0).getName());
     }
+
+    @Test
+    public void hasDefaultPartsizeDefault() throws IOException {
+        final OptionSet options = optionsParser.parse("-v", "vaultname", "--endpoint", ENDPOINT_URL);
+        assertTrue(options.valueOf(optionsParser.partSize).longValue() == 16777216);
+        
+    }
+
+    @Test
+    public void hasDefaultPartsizeCustom() throws IOException {
+        final OptionSet options = optionsParser.parse("-v", "vaultname", "--endpoint", ENDPOINT_URL, "-p", "1048576");
+        assertTrue(options.valueOf(optionsParser.partSize).longValue() == 1048576);
+        
+    }
 }


### PR DESCRIPTION
Made a few changes to the source to support the following:
- Make --help work without a region specified on the command line
- Inject a new AbstractGlacierCommand class to allow that class to verify non-null AWS objects while allowing HelpCommand to be more basic
- Add verifyArguments method to the AbstractCommand class to allow the CLI to verify arguments before invoking the command ie. verifying that the partsize is a power of 2
- Make sure that multipart upload works without a partsize specified on the command line in the sense that it then just falls back to the default value of 4MB
