### PR TITLE
reducing final jar file by import only needed aws dependencies

### DIFF
--- a/glacieruploader-command/pom.xml
+++ b/glacieruploader-command/pom.xml
@@ -27,7 +27,19 @@
 
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-glacier</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sqs</artifactId>
         </dependency>
 
         <dependency>

--- a/glacieruploader-printers/pom.xml
+++ b/glacieruploader-printers/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-glacier</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,10 @@
         <dependencies>
             <dependency>
                 <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk</artifactId>
+                <artifactId>aws-java-sdk-bom</artifactId>
                 <version>1.11.490</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Instead of packaging the entire `aws-java-sdk`, project will add to
its final package only the submodules it needs:
1. aws-java-sdk-core
1. aws-java-sdk-glacier
1. aws-java-sdk-sns
1. aws-java-sdk-sqs